### PR TITLE
Fix contracted_hours field name

### DIFF
--- a/tsm_time_pack/__manifest__.py
+++ b/tsm_time_pack/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "TSM Task Time Service Pack",
     "summary": "Create packs of time which can be consumed in tasks.",
     "category": "Management",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.0.1",
     "development_status": "Beta",
     "website": "https://github.com/Bilbonet/bilbonet-tsm",
     "author": "Jesus Ramiro (Bilbonet),",

--- a/tsm_time_pack/data/tsm_time_pack_email_template.xml
+++ b/tsm_time_pack/data/tsm_time_pack_email_template.xml
@@ -58,11 +58,11 @@
                 <table style="width:100%;background:inherit;color:inherit;">
                     <tbody>
                         <tr style="color:#875A7B;">
-                            <td style="width:100px;padding:5px">Contrated:</td>
+                            <td style="width:100px;padding:5px">Contracted:</td>
                             <td class="text-right">
                                 <span
                                                 style="font-weight: bold;"
-                                                t-out="('%d:%02d' % (object.contrated_hours,(object.contrated_hours*60)%60))"
+                                                t-out="('%d:%02d' % (object.contracted_hours,(object.contracted_hours*60)%60))"
                                             /> hours
                             </td>
                         </tr>

--- a/tsm_time_pack/i18n/es.po
+++ b/tsm_time_pack/i18n/es.po
@@ -62,10 +62,10 @@ msgid ""
 "                <table style=\"width:100%;background:inherit;color:inherit;\">\n"
 "                    <tbody>\n"
 "                        <tr style=\"color:#875A7B;\">\n"
-"                            <td style=\"width:100px;padding:5px\">Contrated:</td>\n"
+"                            <td style=\"width:100px;padding:5px\">Contracted:</td>\n"
 "                            <td class=\"text-right\">\n"
-"                                <span style=\"font-weight: bold;\" t-out=\"('%d:%02d' % (object.contrated_hours,(object."
-"contrated_hours*60)%60))\"/> hours\n"
+"                                <span style=\"font-weight: bold;\" t-out=\"('%d:%02d' % (object.contracted_hours,(object."
+"contracted_hours*60)%60))\"/> hours\n"
 "                            </td>\n"
 "                        </tr>\n"
 "                        <tr style=\"background-color:#dc3545;color:#FFFFFF;\">\n"
@@ -155,8 +155,8 @@ msgstr ""
 "                        <tr style=\"color:#875A7B;\">\n"
 "                            <td style=\"width:100px;padding:5px\">Contratadas:</td>\n"
 "                            <td class=\"text-right\">\n"
-"                                <span style=\"font-weight: bold;\" t-out=\"('%d:%02d' % (object.contrated_hours,(object."
-"contrated_hours*60)%60))\"/> horas\n"
+"                                <span style=\"font-weight: bold;\" t-out=\"('%d:%02d' % (object.contracted_hours,(object."
+"contracted_hours*60)%60))\"/> horas\n"
 "                            </td>\n"
 "                        </tr>\n"
 "                        <tr style=\"background-color:#dc3545;color:#FFFFFF;\">\n"
@@ -221,7 +221,7 @@ msgstr ""
 #. module: tsm_time_pack
 #: code:addons/tsm_time_pack/models/tsm_time_pack.py:0
 #, python-format
-msgid "<h6>Contrated Hours: %s</h6><h6>Consumed Hours: %s</h6><h4 class=\"text-danger\">Progress: %s %%</h4>"
+msgid "<h6>Contracted Hours: %s</h6><h6>Consumed Hours: %s</h6><h4 class=\"text-danger\">Progress: %s %%</h4>"
 msgstr "<h6>Horas Contratadas: %s</h6><h6>Horas Consumidas: %s</h6><h4 class=\"text-danger\">Progreso: %s %%</h4>"
 
 #. module: tsm_time_pack
@@ -263,7 +263,7 @@ msgstr ""
 
 #. module: tsm_time_pack
 #: model_terms:ir.ui.view,arch_db:tsm_time_pack.tsm_time_pack_mine_kanban_view
-msgid "<strong>Contrated Hours: </strong>"
+msgid "<strong>Contracted Hours: </strong>"
 msgstr "<strong>Horas Contratadas: </strong>"
 
 #. module: tsm_time_pack
@@ -400,7 +400,7 @@ msgstr "Cortesia <span class=\"fa fa-arrow-circle-right\"/> :"
 
 #. module: tsm_time_pack
 #: model:ir.model.fields,help:tsm_time_pack.field_tsm_time_pack__remaining_hours
-msgid "Computed as: Contrated hours - Consumed hours"
+msgid "Computed as: Contracted hours - Consumed hours"
 msgstr "Calculadas como: Horas Contratadas - Horas Consumidas"
 
 #. module: tsm_time_pack
@@ -431,18 +431,18 @@ msgstr "Consumido <span class=\"fa fa-arrow-circle-down text-danger\"/> :"
 
 #. module: tsm_time_pack
 #: model_terms:ir.ui.view,arch_db:tsm_time_pack.tsm_time_pack_tree_view
-msgid "Contrated (Hours)"
+msgid "Contracted (Hours)"
 msgstr "Contratadas (Horas)"
 
 #. module: tsm_time_pack
-#: model:ir.model.fields,field_description:tsm_time_pack.field_tsm_time_pack__contrated_hours
-msgid "Contrated Hours"
+#: model:ir.model.fields,field_description:tsm_time_pack.field_tsm_time_pack__contracted_hours
+msgid "Contracted Hours"
 msgstr "Horas Contratadas"
 
 #. module: tsm_time_pack
 #: model_terms:ir.ui.view,arch_db:tsm_time_pack.tsm_time_pack_report_detailed_document
 #: model_terms:ir.ui.view,arch_db:tsm_time_pack.tsm_time_pack_report_summary_document
-msgid "Contrated:"
+msgid "Contracted:"
 msgstr "Contratadas:"
 
 #. module: tsm_time_pack
@@ -817,7 +817,7 @@ msgstr "Cantidad"
 #. module: tsm_time_pack
 #: code:addons/tsm_time_pack/models/tsm_time_pack.py:0
 #, python-format
-msgid "Quantity of hours contrated must be greater than 0."
+msgid "Quantity of hours contracted must be greater than 0."
 msgstr "La cantidad de horas contratadas debe ser mayor que 0."
 
 #. module: tsm_time_pack
@@ -991,7 +991,7 @@ msgid "Time Packs"
 msgstr "Bolsa de horas"
 
 #. module: tsm_time_pack
-#: model:ir.model.fields,help:tsm_time_pack.field_tsm_time_pack__contrated_hours
+#: model:ir.model.fields,help:tsm_time_pack.field_tsm_time_pack__contracted_hours
 msgid "Time contracted by the client for support and it can be consumed in tasks and timesheet."
 msgstr "Tiempo contratado por el cliente para soporte y puede ser consumido en los partes de horas de las tareas."
 

--- a/tsm_time_pack/i18n/tsm_time_pack.pot
+++ b/tsm_time_pack/i18n/tsm_time_pack.pot
@@ -60,9 +60,9 @@ msgid ""
 "                <table style=\"width:100%;background:inherit;color:inherit;\">\n"
 "                    <tbody>\n"
 "                        <tr style=\"color:#875A7B;\">\n"
-"                            <td style=\"width:100px;padding:5px\">Contrated:</td>\n"
+"                            <td style=\"width:100px;padding:5px\">Contracted:</td>\n"
 "                            <td class=\"text-right\">\n"
-"                                <span style=\"font-weight: bold;\" t-out=\"('%d:%02d' % (object.contrated_hours,(object.contrated_hours*60)%60))\"/> hours\n"
+"                                <span style=\"font-weight: bold;\" t-out=\"('%d:%02d' % (object.contracted_hours,(object.contracted_hours*60)%60))\"/> hours\n"
 "                            </td>\n"
 "                        </tr>\n"
 "                        <tr style=\"background-color:#dc3545;color:#FFFFFF;\">\n"
@@ -125,7 +125,7 @@ msgstr ""
 #: code:addons/tsm_time_pack/models/tsm_time_pack.py:0
 #, python-format
 msgid ""
-"<h6>Contrated Hours: %s</h6><h6>Consumed Hours: %s</h6><h4 class=\"text-"
+"<h6>Contracted Hours: %s</h6><h6>Consumed Hours: %s</h6><h4 class=\"text-"
 "danger\">Progress: %s %%</h4>"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 
 #. module: tsm_time_pack
 #: model_terms:ir.ui.view,arch_db:tsm_time_pack.tsm_time_pack_mine_kanban_view
-msgid "<strong>Contrated Hours: </strong>"
+msgid "<strong>Contracted Hours: </strong>"
 msgstr ""
 
 #. module: tsm_time_pack
@@ -300,7 +300,7 @@ msgstr ""
 
 #. module: tsm_time_pack
 #: model:ir.model.fields,help:tsm_time_pack.field_tsm_time_pack__remaining_hours
-msgid "Computed as: Contrated hours - Consumed hours"
+msgid "Computed as: Contracted hours - Consumed hours"
 msgstr ""
 
 #. module: tsm_time_pack
@@ -331,18 +331,18 @@ msgstr ""
 
 #. module: tsm_time_pack
 #: model_terms:ir.ui.view,arch_db:tsm_time_pack.tsm_time_pack_tree_view
-msgid "Contrated (Hours)"
+msgid "Contracted (Hours)"
 msgstr ""
 
 #. module: tsm_time_pack
-#: model:ir.model.fields,field_description:tsm_time_pack.field_tsm_time_pack__contrated_hours
-msgid "Contrated Hours"
+#: model:ir.model.fields,field_description:tsm_time_pack.field_tsm_time_pack__contracted_hours
+msgid "Contracted Hours"
 msgstr ""
 
 #. module: tsm_time_pack
 #: model_terms:ir.ui.view,arch_db:tsm_time_pack.tsm_time_pack_report_detailed_document
 #: model_terms:ir.ui.view,arch_db:tsm_time_pack.tsm_time_pack_report_summary_document
-msgid "Contrated:"
+msgid "Contracted:"
 msgstr ""
 
 #. module: tsm_time_pack
@@ -720,7 +720,7 @@ msgstr ""
 #. module: tsm_time_pack
 #: code:addons/tsm_time_pack/models/tsm_time_pack.py:0
 #, python-format
-msgid "Quantity of hours contrated must be greater than 0."
+msgid "Quantity of hours contracted must be greater than 0."
 msgstr ""
 
 #. module: tsm_time_pack
@@ -894,7 +894,7 @@ msgid "Time Packs"
 msgstr ""
 
 #. module: tsm_time_pack
-#: model:ir.model.fields,help:tsm_time_pack.field_tsm_time_pack__contrated_hours
+#: model:ir.model.fields,help:tsm_time_pack.field_tsm_time_pack__contracted_hours
 msgid ""
 "Time contracted by the client for support and it can be consumed in tasks "
 "and timesheet."

--- a/tsm_time_pack/models/tsm_time_pack.py
+++ b/tsm_time_pack/models/tsm_time_pack.py
@@ -105,9 +105,10 @@ class TsmTimePack(models.Model):
         "- Visible by all employees: Employees "
         "may see all time packs\n",
     )
-    contrated_hours = fields.Float(
+    contracted_hours = fields.Float(
         default=0.0,
         required=True,
+        oldname="contrated_hours",
         help="Time contracted by the client for support and it can be "
         "consumed in tasks and timesheet.",
     )
@@ -122,7 +123,7 @@ class TsmTimePack(models.Model):
         readonly=True,
         store=True,
         digits="Time Pack",
-        help="Computed as: Contrated hours - Consumed hours",
+        help="Computed as: Contracted hours - Consumed hours",
     )
     total_hours_spent = fields.Float(
         compute="_compute_hours",
@@ -193,7 +194,7 @@ class TsmTimePack(models.Model):
     ]
 
     @api.depends(
-        "contrated_hours",
+        "contracted_hours",
         "timesheet_ids",
         "timesheet_ids.amount",
         "timesheet_ids.discount_time",
@@ -213,9 +214,9 @@ class TsmTimePack(models.Model):
             total_hours_spent = sum(time.sudo().timesheet_ids.mapped("amount"))
             consumed_hours = sum(timesheet_consu_ids.mapped("amount"))
             complimentary_hours = total_hours_spent - consumed_hours
-            remaining_hours = time.contrated_hours - consumed_hours
-            if time.contrated_hours > 0.0:
-                progress = round((100.0 * consumed_hours) / time.contrated_hours, 2)
+            remaining_hours = time.contracted_hours - consumed_hours
+            if time.contracted_hours > 0.0:
+                progress = round((100.0 * consumed_hours) / time.contracted_hours, 2)
             else:
                 progress = 0.0
 
@@ -230,10 +231,10 @@ class TsmTimePack(models.Model):
             )
 
             if progress >= 90:
-                cont_hours = self._format_hours(time.contrated_hours)
+                cont_hours = self._format_hours(time.contracted_hours)
                 consu_hours = self._format_hours(consumed_hours)
                 txt_msg = _(
-                    "<h6>Contrated Hours: {cont_hours}</h6>"
+                    "<h6>Contracted Hours: {cont_hours}</h6>"
                     "<h6>Consumed Hours: {consu_hours}</h6>"
                     '<h4 class="text-danger">Progress: {progress} %</h4>'
                 ).format(
@@ -310,10 +311,10 @@ class TsmTimePack(models.Model):
     def _check_quantity(self):
         if not self.quantity > 0.0:
             raise ValidationError(
-                _("Quantity of hours contrated must be greater than 0.")
+                _("Quantity of hours contracted must be greater than 0.")
             )
         else:
-            self.contrated_hours = self.quantity
+            self.contracted_hours = self.quantity
 
     @api.constrains("discount")
     def _check_discount(self):

--- a/tsm_time_pack/report/tsm_time_pack_report.xml
+++ b/tsm_time_pack/report/tsm_time_pack_report.xml
@@ -87,10 +87,10 @@
                                     <div class="col-4">
                                         <table class="table table-sm table-borderless">
                                             <tr>
-                                                <td>Contrated:</td>
+                                                <td>Contracted:</td>
                                                 <td class="text-right text-primary">
                                                     <span
-                                                        t-field="o.contrated_hours"
+                                                        t-field="o.contracted_hours"
                                                         t-options="{'widget': 'float_time'}"
                                                     /> hours
                                                 </td>
@@ -342,10 +342,10 @@
                                     <div class="col-4">
                                         <table class="table table-sm table-borderless">
                                             <tr>
-                                                <td>Contrated:</td>
+                                                <td>Contracted:</td>
                                                 <td class="text-right text-primary">
                                                     <span
-                                                        t-field="o.contrated_hours"
+                                                        t-field="o.contracted_hours"
                                                         t-options="{'widget': 'float_time'}"
                                                     /> hours
                                                 </td>

--- a/tsm_time_pack/views/tsm_time_pack_view.xml
+++ b/tsm_time_pack/views/tsm_time_pack_view.xml
@@ -132,7 +132,7 @@
                             <group>
                                 <group>
                                     <field
-                                        name="contrated_hours"
+                                        name="contracted_hours"
                                         widget="float_time"
                                         attrs="{'readonly':[('can_edit','=',False)]}"
                                     />
@@ -272,8 +272,8 @@
                 <field name="code" />
                 <field name="name" />
                 <field
-                    name="contrated_hours"
-                    string="Contrated (Hours)"
+                    name="contracted_hours"
+                    string="Contracted (Hours)"
                     sum="Total time"
                     widget="float_time"
                 />
@@ -359,7 +359,7 @@
                 <field name="user_id" />
                     <field name="code" />
                 <field name="name" />
-                <field name="contrated_hours" />
+                <field name="contracted_hours" />
                 <templates>
                     <t t-name="kanban-box">
                         <div t-attf-class="oe_kanban_global_click">
@@ -397,8 +397,8 @@
                                 <t t-esc="record.date_start.value" />
                             </span>
                             <span class="pull-right">
-                                <strong>Contrated Hours: </strong><field
-                                    name="contrated_hours"
+                                <strong>Contracted Hours: </strong><field
+                                    name="contracted_hours"
                                     widget="float_time"
                                 />
                             </span>


### PR DESCRIPTION
## Summary
- rename `contrated_hours` to `contracted_hours`
- update views, reports and templates
- adjust translations
- bump module version

## Testing
- `pre-commit run --files tsm_time_pack/__manifest__.py tsm_time_pack/data/tsm_time_pack_email_template.xml tsm_time_pack/i18n/es.po tsm_time_pack/i18n/tsm_time_pack.pot tsm_time_pack/models/tsm_time_pack.py tsm_time_pack/report/tsm_time_pack_report.xml tsm_time_pack/views/tsm_time_pack_view.xml`

------
https://chatgpt.com/codex/tasks/task_e_685ac7f143e08320b54118959235e73f